### PR TITLE
Updated the variable spending method

### DIFF
--- a/js/spendingModule.js
+++ b/js/spendingModule.js
@@ -46,7 +46,7 @@ var SpendingModule = {
             if (isInitialYearInCycle) {
                 return form.spending.initial;
             } else if (isAfterInitialYearInCycle) {
-                var spendingAdjustment = ((sim[i][j].portfolio.start / sim[i][0].portfolio.start - 1) * form.spending.variableSpendingZValue) + 1;
+                var spendingAdjustment = ((sim[i][j].portfolio.start / (sim[i][0].portfolio.start * sim[i][j].cumulativeInflation) - 1) * form.spending.variableSpendingZValue) + 1;
                 var spending = form.spending.initial * spendingAdjustment * sim[i][j].cumulativeInflation;
                 return Math.min(ceiling, Math.max(floor, spending));
             }

--- a/js/spendingModule.js
+++ b/js/spendingModule.js
@@ -40,14 +40,15 @@ var SpendingModule = {
             var isInitialYearInCycle = j == (form.retirementStartYear - currentYear);
             var isAfterInitialYearInCycle = j > (form.retirementStartYear - currentYear);
 
-            var floor = form.spending.floor == 'definedValue' ? form.spending.floorValue * sim[i][j].cumulativeInflation : 0;
+            var floor = (form.spending.floor == 'definedValue') && ("floorValue" in form.spending) ? form.spending.floorValue * sim[i][j].cumulativeInflation : Number.NEGATIVE_INFINITY;
+            var ceiling = (form.spending.ceiling == 'definedValue') && ("ceilingValue" in form.spending) ? form.spending.ceilingValue * sim[i][j].cumulativeInflation : Number.POSITIVE_INFINITY;
 
             if (isInitialYearInCycle) {
                 return form.spending.initial;
             } else if (isAfterInitialYearInCycle) {
                 var spendingAdjustment = ((sim[i][j].portfolio.start / sim[i][0].portfolio.start - 1) * form.spending.variableSpendingZValue) + 1;
                 var spending = form.spending.initial * spendingAdjustment * sim[i][j].cumulativeInflation;
-                return Math.max(floor, spending);
+                return Math.min(ceiling, Math.max(floor, spending));
             }
             return 0;
         }
@@ -55,7 +56,7 @@ var SpendingModule = {
     "percentOfPortfolio": {
         calcSpending: function(form, sim, i, j) {
         	var spending = 0;
-        	if(form.spending.percentageOfPortfolioType == "withFloorAndCeiling"){
+        	if(form.spending.percentageOfPortfolioType == "withFloorAndCeiling") {
         		//Calculate floor value
         		var floor;
 				if (form.spending.percentageOfPortfolioFloorType == "percentageOfPortfolio") {

--- a/js/spendingModule.js
+++ b/js/spendingModule.js
@@ -36,22 +36,20 @@ var SpendingModule = {
     },
     "variableSpending": {
         calcSpending: function(form, sim, i, j) {
-            var spending = 0;
             var currentYear = new Date().getFullYear();
-            if (j == (form.retirementStartYear - currentYear)) {
-                spending = form.spending.initial;
-            } else if (j > (form.retirementStartYear - currentYear)) {
-                if (sim[i][j - 1].portfolio.start > sim[i][j].portfolio.start) {
-                    var loss = (sim[i][j - 1].portfolio.start - sim[i][j].portfolio.start) / sim[i][j - 1].portfolio.start;
-                    var adjustedLoss = 1 - (loss * form.spending.variableSpendingZValue);
-                    spending = adjustedLoss * sim[i][j - 1].infAdjSpending * sim[i][j].cumulativeInflation;
-                } else if (sim[i][j].portfolio.start > sim[i][j - 1].portfolio.start) {
-                    var gain = (sim[i][j].portfolio.start - sim[i][j - 1].portfolio.start) / sim[i][j - 1].portfolio.start;
-                    var adjustedGain = 1 + (gain * form.spending.variableSpendingZValue);
-                    spending = adjustedGain * sim[i][j - 1].infAdjSpending * sim[i][j].cumulativeInflation;
-                }
+            var isInitialYearInCycle = j == (form.retirementStartYear - currentYear);
+            var isAfterInitialYearInCycle = j > (form.retirementStartYear - currentYear);
+
+            var floor = form.spending.floor == 'definedValue' ? form.spending.floorValue * sim[i][j].cumulativeInflation : 0;
+
+            if (isInitialYearInCycle) {
+                return form.spending.initial;
+            } else if (isAfterInitialYearInCycle) {
+                var spendingAdjustment = ((sim[i][j].portfolio.start / sim[i][0].portfolio.start - 1) * form.spending.variableSpendingZValue) + 1;
+                var spending = form.spending.initial * spendingAdjustment * sim[i][j].cumulativeInflation;
+                return Math.max(floor, spending);
             }
-            return spending;
+            return 0;
         }
     },
     "percentOfPortfolio": {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,0 +1,66 @@
+// Karma configuration
+// Generated on Tue Mar 03 2015 13:06:55 GMT-0800 (Pacific Standard Time)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: '../',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+    files: [
+      'js/spendingModule.js',
+      'test/*.js'
+    ],
+
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+    autoWatchInterval: 100,
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/test/spendingModuleTests.js
+++ b/test/spendingModuleTests.js
@@ -1,0 +1,98 @@
+'use strict';
+
+describe("variableSpending", function() {
+
+    it("should calculate the first years spending in a cycle equal to the initial spending value", function() {
+        var form = {
+            retirementStartYear: new Date().getFullYear(),
+            spending: { initial: 40000 }
+        };
+
+        var actualSpending = SpendingModule['variableSpending'].calcSpending(form, null, 0, 0);
+
+        expect(actualSpending).toBe(form.spending.initial);
+    });
+
+    describe("when the portfolio value decreases from last year", function() {
+
+        it("should adjust the next years spending by the change in portfolio value multiplied by the variable spending ratio", function() {
+            var form = {
+                retirementStartYear: new Date().getFullYear(),
+                spending: { initial: 40000, variableSpendingZValue: 0.5 }
+            };
+            var sim = [
+                [
+                    { portfolio: { start: 1000000 } },
+                    { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
+                ]
+            ];
+
+            var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+            expect(actualSpending).toBe(38000 * 1.05);
+        });
+
+        describe("and it hits the floor", function() {
+
+            it("should return the floor", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue", floorValue: 40000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(40000 * 1.05);
+            });
+        });
+    });
+
+    describe("when the portfolio value increases from last year", function() {
+
+        it("should adjust the next years spending by the change in portfolio value multiplied by the variable spending ratio", function() {
+            var form = {
+                retirementStartYear: new Date().getFullYear(),
+                spending: { initial: 40000, variableSpendingZValue: 0.5 }
+            };
+            var sim = [
+                [
+                    { portfolio: { start: 1000000 } },
+                    { portfolio: { start: 1100000 }, cumulativeInflation: 1 }
+                ]
+            ];
+
+            var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+            expect(actualSpending).toBe(42000);
+        });
+
+        describe("and it goes above the floor", function() {
+
+            it("should return the floor", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue", floorValue: 40000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 } },
+                        { portfolio: { start: 1100000 }, cumulativeInflation: 1 },
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 2);
+
+                expect(actualSpending).toBe(42000);
+            });
+        });
+    });
+});

--- a/test/spendingModuleTests.js
+++ b/test/spendingModuleTests.js
@@ -29,7 +29,8 @@ describe("variableSpending", function() {
 
             var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
 
-            expect(actualSpending).toBe(38000 * 1.05);
+            var expectedSpendingAdjustment = (((900000 / (1000000 * 1.05) - 1) * 0.5) + 1)
+            expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
         });
 
         describe("and it hits the floor", function() {
@@ -70,11 +71,12 @@ describe("variableSpending", function() {
 
                 var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
 
-                expect(actualSpending).toBe(38000 * 1.05);
+                var expectedSpendingAdjustment = (((900000 / (1000000 * 1.05) - 1) * 0.5) + 1)
+                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
             });
         });
 
-        describe("and it goes below the ceiling", function() {
+        describe("and it goes back below the ceiling", function() {
 
             it("should return the adjusted spending", function() {
 
@@ -92,7 +94,8 @@ describe("variableSpending", function() {
 
                 var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 2);
 
-                expect(actualSpending).toBe(40000 * 1.05);
+                var expectedSpendingAdjustment = (((1000000 / (1000000 * 1.05) - 1) * 0.5) + 1);
+                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
             });
         });
 
@@ -113,7 +116,8 @@ describe("variableSpending", function() {
 
                 var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
 
-                expect(actualSpending).toBe(60000 * 1.05);
+                var expectedSpendingAdjustment = (((2000000 / (1000000 * 1.05) - 1) * 0.5) + 1);
+                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
             });
         });
     });

--- a/test/spendingModuleTests.js
+++ b/test/spendingModuleTests.js
@@ -52,6 +52,70 @@ describe("variableSpending", function() {
                 expect(actualSpending).toBe(40000 * 1.05);
             });
         });
+
+        describe("and the floor is null", function() {
+
+            it("should not have a floor", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue" }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(38000 * 1.05);
+            });
+        });
+
+        describe("and it goes below the ceiling", function() {
+
+            it("should return the adjusted spending", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue", ceilingValue: 60000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 3000000 } },
+                        { portfolio: { start: 1000000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 2);
+
+                expect(actualSpending).toBe(40000 * 1.05);
+            });
+        });
+
+        describe("and the ceiling is null", function() {
+
+            it("should not have a ceiling", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue" }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 2000000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(60000 * 1.05);
+            });
+        });
     });
 
     describe("when the portfolio value increases from last year", function() {
@@ -75,7 +139,7 @@ describe("variableSpending", function() {
 
         describe("and it goes above the floor", function() {
 
-            it("should return the floor", function() {
+            it("should return the adjusted spending", function() {
 
                 var form = {
                     retirementStartYear: new Date().getFullYear(),
@@ -92,6 +156,27 @@ describe("variableSpending", function() {
                 var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 2);
 
                 expect(actualSpending).toBe(42000);
+            });
+        });
+
+        describe("and it hits the ceiling", function() {
+
+            it("should return the ceiling", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue", ceilingValue: 60000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 3000000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(60000 * 1.05);
             });
         });
     });


### PR DESCRIPTION
Hey,

The variable spending method wasn't taking into account floor and ceiling values.  Also, the spending amount was being affected by inflation so similar portfolio values across different cycles had different spending rates (it was causing some really wonky withdrawal rates during the 70's and 80's).  I wasn't exactly sure how the spending method was suppose to work, so let me know if I was off base.  This also doesn't account for the "Pensions/SS" floor value as I couldn't figure out how to calculate that value.

I also included some bdd style tests using Karma/Jasmine.  Feel free to remove them if you don't want them.