### PR TITLE
Fixed some bugs with the % of portfolio spending method

### DIFF
--- a/js/spendingModule.js
+++ b/js/spendingModule.js
@@ -58,35 +58,22 @@ var SpendingModule = {
         	var spending = 0;
         	if(form.spending.percentageOfPortfolioType == "withFloorAndCeiling") {
         		//Calculate floor value
-        		var floor;
-				if (form.spending.percentageOfPortfolioFloorType == "percentageOfPortfolio") {
-                    floor = sim[0][0].portfolio.start * (form.spending.percentageOfPortfolioFloorPercentage / 100);
-                }else if(form.spending.percentageOfPortfolioFloorType == "percentageOfPreviousYear"){
-                	floor = sim[i][j - 1].spending * (form.spending.percentageOfPortfolioFloorPercentage / 100);
-                }else if(form.spending.percentageOfPortfolioFloorType == "none"){
-					floor = 0;
+        		var floor = 0;
+				if (form.spending.percentageOfPortfolioFloorType == "percentageOfPortfolio" && "percentageOfPortfolioFloorPercentage" in form.spending) {
+                    floor = sim[0][0].portfolio.start * (form.spending.percentageOfPortfolioFloorPercentage / 100) * sim[i][j].cumulativeInflation;
+                }else if(form.spending.percentageOfPortfolioFloorType == "percentageOfPreviousYear" && "percentageOfPortfolioFloorPercentage" in form.spending && form.spending.percentageOfPortfolioFloorPercentage != ""){
+                    floor = (j == 0) ? 0 : sim[i][j - 1].spending * (form.spending.percentageOfPortfolioFloorPercentage / 100);
                 }
 
                 //Calculate Ceiling
-                var ceiling;
-				if (form.spending.percentageOfPortfolioCeilingType == "percentageOfPortfolio") {
-                    ceiling = sim[0][0].portfolio.start * (form.spending.percentageOfPortfolioCeilingPercentage / 100);
-                }else if(form.spending.percentageOfPortfolioCeilingType == "percentageOfPreviousYear"){
-                	ceiling = sim[i][j - 1].spending * (form.spending.percentageOfPortfolioCeilingPercentage / 100);
-                }else if(form.spending.percentageOfPortfolioCeilingType == "none"){
-					ceiling = 0;
+                var ceiling = Number.POSITIVE_INFINITY;
+				if (form.spending.percentageOfPortfolioCeilingType == "percentageOfPortfolio" && "percentageOfPortfolioCeilingPercentage" in form.spending && form.spending.percentageOfPortfolioCeilingPercentage != "") {
+                    ceiling = sim[0][0].portfolio.start * (form.spending.percentageOfPortfolioCeilingPercentage / 100) * sim[i][j].cumulativeInflation;
                 }
 
                 //Determine spending based on floor/ceiling values and the given % of portfolio value
                 var baseSpending = sim[i][j].portfolio.start * (form.spending.percentageOfPortfolioPercentage/100);
-                if(baseSpending > ceiling){
-                	spending = ceiling;
-                }else if(baseSpending < floor){
-                	spending = floor;
-                }else{
-                	spending = baseSpending;
-                }
-
+                spending = Math.min(ceiling, Math.max(floor, baseSpending))
         	}else{
         		spending = sim[i][j].portfolio.start * (form.spending.percentageOfPortfolioPercentage/100);
         	}

--- a/test/spendingModuleTests.js
+++ b/test/spendingModuleTests.js
@@ -185,3 +185,246 @@ describe("variableSpending", function() {
         });
     });
 });
+
+describe("percentOfPortfolio", function() {
+
+    describe("when the portfolio value decreases from last year", function() {
+
+        it("should lower the spending based on portfolio size", function() {
+            var form = {
+                retirementStartYear: new Date().getFullYear(),
+                spending: { percentageOfPortfolioPercentage: 4, percentageOfPortfolioType: "constant" }
+            };
+            var sim = [
+                [
+                    { portfolio: { start: 1000000 } },
+                    { portfolio: { start: 900000 } }
+                ]
+            ];
+
+            var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+            expect(actualSpending).toBe(900000 * 0.04);
+        });
+
+        describe("and there is a percentage of portfolio floor that is hit", function() {
+
+            it("should lower the spending to the floor", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioType: "withFloorAndCeiling",
+                        percentageOfPortfolioFloorType: "percentageOfPortfolio",
+                        percentageOfPortfolioFloorPercentage: 3,
+                        percentageOfPortfolioCeilingType: "none"
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 500000 }, cumulativeInflation: 1.1 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(1000000 * 0.03 * 1.1);
+            });
+        });
+
+        describe("and there is a percentage of previous year floor that is hit", function() {
+
+            it("should lower the spending to the floor", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioType: "withFloorAndCeiling",
+                        percentageOfPortfolioFloorType: "percentageOfPreviousYear",
+                        percentageOfPortfolioFloorPercentage: 95,
+                        percentageOfPortfolioCeilingType: "none"
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 }, spending: 40000 },
+                        { portfolio: { start: 900000 } }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(40000 * 0.95);
+            });
+        });
+
+        describe("and the floor is set to no limit", function() {
+
+            it("should lower the spending based on portfolio size", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioType: "withFloorAndCeiling",
+                        percentageOfPortfolioFloorType: "none",
+                        percentageOfPortfolioCeilingType: "none"
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 } }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(900000 * 0.04);
+            });
+        });
+
+        describe("and there is no percentageOfPortfolioFloorPercentage", function() {
+
+            it("should have no floor", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioType: "withFloorAndCeiling",
+                        percentageOfPortfolioFloorType: "percentageOfPortfolio"
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 } }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(900000 * 0.04);
+            });
+        });
+
+        describe("and there is no percentageOfPortfolioFloorPercentage for percentage of previous year", function() {
+
+            it("should have no floor", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioType: "withFloorAndCeiling",
+                        percentageOfPortfolioFloorType: "percentageOfPreviousYear"
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 } }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(900000 * 0.04);
+            });
+        });
+    });
+
+    describe("when the portfolio value increases from last year", function() {
+
+        it("should raise the spending based on portfolio size", function() {
+            var form = {
+                retirementStartYear: new Date().getFullYear(),
+                spending: { percentageOfPortfolioPercentage: 4, percentageOfPortfolioType: "constant" }
+            };
+            var sim = [
+                [
+                    { portfolio: { start: 1000000 } },
+                    { portfolio: { start: 1100000 } }
+                ]
+            ];
+
+            var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+            expect(actualSpending).toBe(1100000 * 0.04);
+        });
+
+        describe("and there is a percentage of portfolio ceiling that is hit", function() {
+
+            it("should raise the spending to the ceiling", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioType: "withFloorAndCeiling",
+                        percentageOfPortfolioFloorType: "none",
+                        percentageOfPortfolioCeilingType: "percentageOfPortfolio",
+                        percentageOfPortfolioCeilingPercentage: 6
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 2000000 }, cumulativeInflation: 1.1 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(1000000 * 0.06 * 1.1);
+            });
+        });
+
+        describe("and the celing is set to no limit", function() {
+
+            it("should raise the spending based on portfolio size", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioType: "withFloorAndCeiling",
+                        percentageOfPortfolioFloorType: "none",
+                        percentageOfPortfolioCeilingType: "none"
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 2000000 } }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(2000000 * 0.04);
+            });
+        });
+
+        describe("and there is no percentageOfPortfolioCeilingPercentage", function() {
+
+            it("should have no ceiling", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioType: "withFloorAndCeiling",
+                        percentageOfPortfolioCeilingType: "percentageOfPortfolio"
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 } }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(900000 * 0.04);
+            });
+        });
+    });
+});


### PR DESCRIPTION
I mistyped the commit message.  This updates the "% of portfolio" spending method.  Here's the bugs fixed/changes made:

- "No Limit" ceiling wasn't working (set to 0 rather than positive infinity)
- "% of previous year" floor and ceiling wasn't working at all (was hitting an out of bounds array error for the first year in every cycle).
- Had a "% of previous year" path for ceiling values even though it doesn't exist in the UI.  Removed the path from code.
- Wasn't taking into account inflation for "As a % of Starting Portfolio" floor and ceilings.  Caused interesting results for cycles that went through stagflation.
- Used Math.min and Math.max to set the spending floor and ceiling values.