### PR TITLE
Implemented pension/ss and defined value floors/ceilings for all valid spending methods.

### DIFF
--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -225,6 +225,7 @@ var Simulation = {
                     "val": null
                 },
                 "cumulativeInflation": this.cumulativeInflation(startCPI, data.cpi),
+                "socialSecurityAndPensionAdjustments": null,
                 "sumOfAdjustments": null,
             });
         }
@@ -346,23 +347,25 @@ var Simulation = {
     },
     calcSumOfAdjustments: function(form, i, j) { //Calculate the sum of all portfolio adjustments for a given year (pensions, extra income, extra spending, etc)
         var currentYear = new Date().getFullYear();
+        var socialSecurityAndPensionAdjustments = 0;
         var sumOfAdjustments = 0;
         //Evaluate ExtraIncome given cycle i, year j
         //Social Security - always adjusted by CPI
         if ((j >= (form.extraIncome.socialSecurity.startYear - currentYear)) && (j <= (form.extraIncome.socialSecurity.endYear - currentYear))) {
-            sumOfAdjustments += (form.extraIncome.socialSecurity.val * this.sim[i][j].cumulativeInflation);
+            socialSecurityAndPensionAdjustments += (form.extraIncome.socialSecurity.val * this.sim[i][j].cumulativeInflation);
         }
         if ((j >= (form.extraIncome.socialSecuritySpouse.startYear - currentYear)) && (j <= (form.extraIncome.socialSecuritySpouse.endYear - currentYear))) {
-            sumOfAdjustments += (form.extraIncome.socialSecuritySpouse.val * this.sim[i][j].cumulativeInflation);
+            socialSecurityAndPensionAdjustments += (form.extraIncome.socialSecuritySpouse.val * this.sim[i][j].cumulativeInflation);
         }
 
         //Pensions
         for (var k = 0; k < form.extraIncome.pensions.length; k++) {
             if ((j >= (form.extraIncome.pensions[k].startYear - currentYear))) {
-                sumOfAdjustments += this.calcAdjustmentVal(form.extraIncome.pensions[k], i, j);
+                socialSecurityAndPensionAdjustments += this.calcAdjustmentVal(form.extraIncome.pensions[k], i, j);
             }
         }
 
+        sumOfAdjustments += socialSecurityAndPensionAdjustments;
         //Extra Savings
         for (var k = 0; k < form.extraIncome.extraSavings.length; k++) {
             if (form.extraIncome.extraSavings[k].recurring == true) {
@@ -390,6 +393,7 @@ var Simulation = {
         }
 
         //Add sumOfAdjustments to sim container and return value.
+        this.sim[i][j].socialSecurityAndPensionAdjustments = socialSecurityAndPensionAdjustments;
         this.sim[i][j].sumOfAdjustments = sumOfAdjustments;
         return sumOfAdjustments;
     },

--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -165,6 +165,7 @@ var Simulation = {
         for (var i = 0; i < this.sim.length; i++) {
             for (var j = 0; j < this.sim[i].length; j++) {
                 this.calcStartPortfolio(form, i, j); //Return Starting portfolio value to kick off yearly simulation cycles
+                this.calcSumOfAdjustments(form, i, j);
                 this.calcSpending(form, i, j); //Nominal spending for this specific cycle
                 this.calcMarketGains(form, i, j); //Calculate market gains on portfolio based on allocation from form and data points
                 this.calcEndPortfolio(form, i, j); //Sum up ending portfolio
@@ -261,7 +262,7 @@ var Simulation = {
     },
     calcMarketGains: function(form, i, j) {
         var portfolio = this.sim[i][j].portfolio.start;
-        var sumOfAdjustments = this.calcSumOfAdjustments(form, i, j); //Sum of all portfolio adjustments for this given year. SS/Pensions/Extra Income/Extra Spending.
+        var sumOfAdjustments = this.sim[i][j].sumOfAdjustments; //Sum of all portfolio adjustments for this given year. SS/Pensions/Extra Income/Extra Spending.
         portfolio = portfolio - this.sim[i][j].spending + sumOfAdjustments; //Take out spending and portfolio adjustments before calculating asset allocation. This simulates taking your spending out at the beginning of a year.
 
         //Calculate value of each asset class based on allocation percentages

--- a/js/spendingModule.js
+++ b/js/spendingModule.js
@@ -65,6 +65,8 @@ var SpendingModule = {
                 floor = (j == 0) ? 0 : (sim[i][j - 1].spending * (form.spending.percentageOfPortfolioFloorValue / 100)  * sim[i][j].cumulativeInflation / sim[i][j-1].cumulativeInflation);
             }else if(form.spending.percentageOfPortfolioFloorType == "definedValue" && "percentageOfPortfolioFloorValue" in form.spending && form.spending.percentageOfPortfolioFloorValue != "") {
                 floor = form.spending.percentageOfPortfolioFloorValue * sim[i][j].cumulativeInflation;
+            }else if(form.spending.percentageOfPortfolioFloorType == "pensions" && sim[i][j].socialSecurityAndPensionAdjustments != null) {
+                floor = sim[i][j].socialSecurityAndPensionAdjustments;
             }
 
             //Calculate Ceiling

--- a/js/spendingModule.js
+++ b/js/spendingModule.js
@@ -20,7 +20,9 @@ var SpendingModule = {
     },
     "notInflationAdjusted": {
         calcSpending: function(form, sim, i, j) {
-            return (form.spending.initial);
+            var floor = SpendingModule.calcBasicSpendingFloor(form, sim, i, j);
+            var ceiling = SpendingModule.calcBasicSpendingCeiling(form, sim, i, j);
+            return Math.min(ceiling, Math.max(floor, form.spending.initial));
         }
     },
     "hebelerAutopilot": {
@@ -31,7 +33,12 @@ var SpendingModule = {
             var rmdWeight = parseInt(form.spending.hebelerWeightedRMD) / 100;
             var cpiWeight = parseInt(form.spending.hebelerWeightedCPI) / 100;
             var rmdPortfolio = (sim[i][j].portfolio.start / rmdFactor);
-            return (((form.spending.initial * sim[i][j].cumulativeInflation * cpiWeight) + (rmdPortfolio * rmdWeight)));
+
+            var floor = SpendingModule.calcBasicSpendingFloor(form, sim, i, j);
+            var ceiling = SpendingModule.calcBasicSpendingCeiling(form, sim, i, j);
+
+            var baseSpending = (((form.spending.initial * sim[i][j].cumulativeInflation * cpiWeight) + (rmdPortfolio * rmdWeight)));
+            return Math.min(ceiling, Math.max(floor, baseSpending));
         },
     },
     "variableSpending": {
@@ -40,8 +47,8 @@ var SpendingModule = {
             var isInitialYearInCycle = j == (form.retirementStartYear - currentYear);
             var isAfterInitialYearInCycle = j > (form.retirementStartYear - currentYear);
 
-            var floor = (form.spending.floor == 'definedValue') && ("floorValue" in form.spending) ? form.spending.floorValue * sim[i][j].cumulativeInflation : Number.NEGATIVE_INFINITY;
-            var ceiling = (form.spending.ceiling == 'definedValue') && ("ceilingValue" in form.spending) ? form.spending.ceilingValue * sim[i][j].cumulativeInflation : Number.POSITIVE_INFINITY;
+            var floor = SpendingModule.calcBasicSpendingFloor(form, sim, i, j);
+            var ceiling = SpendingModule.calcBasicSpendingCeiling(form, sim, i, j);
 
             if (isInitialYearInCycle) {
                 return form.spending.initial;
@@ -101,9 +108,9 @@ var SpendingModule = {
             var currentWithdrawalRate = sim[i][j-1].spending / sim[i][j].portfolio.start;
             var exceedsRate = initialWithdrawalRate * (1 + exceeds);
             var fallRate = initialWithdrawalRate * (1 - fall);
-
-            var floor = form.spending.floor == "definedValue" ? form.spending.floorValue * sim[i][j].cumulativeInflation : 0;
-            var ceiling = form.spending.ceiling == "definedValue" ? form.spending.ceilingValue * sim[i][j].cumulativeInflation : Number.POSITIVE_INFINITY;
+            
+            var floor = SpendingModule.calcBasicSpendingFloor(form, sim, i, j);
+            var ceiling = SpendingModule.calcBasicSpendingCeiling(form, sim, i, j);
 
             var currentYearInflation = ((sim[i][j].cumulativeInflation - sim[i][j-1].cumulativeInflation) / sim[i][j-1].cumulativeInflation + 1);
             var simulationDuration = form.retirementEndYear - form.retirementStartYear + 1;
@@ -118,5 +125,16 @@ var SpendingModule = {
             }
             return sim[i][j-1].spending * currentYearInflation;
         }
+    },
+    calcBasicSpendingFloor: function(form, sim, i, j) {
+        if(form.spending.floor == 'definedValue' && "floorValue" in form.spending) {
+            return form.spending.floorValue * sim[i][j].cumulativeInflation;
+        } else if (form.spending.floor == "pensions" && sim[i][j].socialSecurityAndPensionAdjustments != null){
+            return sim[i][j].socialSecurityAndPensionAdjustments;
+        }
+        return 0;
+    },
+    calcBasicSpendingCeiling: function(form, sim, i, j) {
+        return form.spending.ceiling == "definedValue" && form.spending.ceilingValue != null ? form.spending.ceilingValue * sim[i][j].cumulativeInflation : Number.POSITIVE_INFINITY;
     }
 };

--- a/test/spendingModuleTests.js
+++ b/test/spendingModuleTests.js
@@ -1,186 +1,66 @@
 'use strict';
 
-describe("variableSpending", function() {
-
-    it("should calculate the first years spending in a cycle equal to the initial spending value", function() {
-        var form = {
-            retirementStartYear: new Date().getFullYear(),
-            spending: { initial: 40000 }
-        };
-
-        var actualSpending = SpendingModule['variableSpending'].calcSpending(form, null, 0, 0);
-
-        expect(actualSpending).toBe(form.spending.initial);
-    });
+describe("notInflationAdjusted", function() {
 
     describe("when the portfolio value decreases from last year", function() {
 
-        it("should adjust the next years spending by the change in portfolio value multiplied by the variable spending ratio", function() {
-            var form = {
-                retirementStartYear: new Date().getFullYear(),
-                spending: { initial: 40000, variableSpendingZValue: 0.5 }
-            };
-            var sim = [
-                [
-                    { portfolio: { start: 1000000 } },
-                    { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
-                ]
-            ];
+        describe("and there is no floor", function() {
 
-            var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
-
-            var expectedSpendingAdjustment = (((900000 / (1000000 * 1.05) - 1) * 0.5) + 1)
-            expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
-        });
-
-        describe("and it hits the floor", function() {
-
-            it("should return the floor", function() {
-
+            it("should return the initial spending amount", function() {
                 var form = {
                     retirementStartYear: new Date().getFullYear(),
-                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue", floorValue: 40000 }
+                    spending: { initial: 40000 }
                 };
                 var sim = [
                     [
                         { portfolio: { start: 1000000 } },
-                        { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
-                    ]
-                ];
-
-                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
-
-                expect(actualSpending).toBe(40000 * 1.05);
-            });
-        });
-
-        describe("and the floor is null", function() {
-
-            it("should not have a floor", function() {
-
-                var form = {
-                    retirementStartYear: new Date().getFullYear(),
-                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue" }
-                };
-                var sim = [
-                    [
-                        { portfolio: { start: 1000000 } },
-                        { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
-                    ]
-                ];
-
-                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
-
-                var expectedSpendingAdjustment = (((900000 / (1000000 * 1.05) - 1) * 0.5) + 1)
-                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
-            });
-        });
-
-        describe("and it goes back below the ceiling", function() {
-
-            it("should return the adjusted spending", function() {
-
-                var form = {
-                    retirementStartYear: new Date().getFullYear(),
-                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue", ceilingValue: 60000 }
-                };
-                var sim = [
-                    [
-                        { portfolio: { start: 1000000 } },
-                        { portfolio: { start: 3000000 } },
                         { portfolio: { start: 1000000 }, cumulativeInflation: 1.05 }
                     ]
                 ];
 
-                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 2);
+                var actualSpending = SpendingModule['notInflationAdjusted'].calcSpending(form, sim, 0, 1);
 
-                var expectedSpendingAdjustment = (((1000000 / (1000000 * 1.05) - 1) * 0.5) + 1);
-                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
+                expect(actualSpending).toBe(40000);
             });
         });
 
-        describe("and the ceiling is null", function() {
+        describe("and there is a defined value floor that is hit", function() {
 
-            it("should not have a ceiling", function() {
-
+            it("should return the floor", function() {
                 var form = {
                     retirementStartYear: new Date().getFullYear(),
-                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue" }
+                    spending: { initial: 40000, floor: "definedValue", floorValue: 35000 }
                 };
                 var sim = [
                     [
                         { portfolio: { start: 1000000 } },
-                        { portfolio: { start: 2000000 }, cumulativeInflation: 1.05 }
+                        { portfolio: { start: 1000000 }, cumulativeInflation: 1.5 }
                     ]
                 ];
 
-                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+                var actualSpending = SpendingModule['notInflationAdjusted'].calcSpending(form, sim, 0, 1);
 
-                var expectedSpendingAdjustment = (((2000000 / (1000000 * 1.05) - 1) * 0.5) + 1);
-                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
+                expect(actualSpending).toBe(35000 * 1.5);
             });
         });
-    });
 
-    describe("when the portfolio value increases from last year", function() {
+        describe("and there is a pension floor that is hit", function() {
 
-        it("should adjust the next years spending by the change in portfolio value multiplied by the variable spending ratio", function() {
-            var form = {
-                retirementStartYear: new Date().getFullYear(),
-                spending: { initial: 40000, variableSpendingZValue: 0.5 }
-            };
-            var sim = [
-                [
-                    { portfolio: { start: 1000000 } },
-                    { portfolio: { start: 1100000 }, cumulativeInflation: 1 }
-                ]
-            ];
-
-            var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
-
-            expect(actualSpending).toBe(42000);
-        });
-
-        describe("and it goes above the floor", function() {
-
-            it("should return the adjusted spending", function() {
-
+            it("should return the floor", function() {
                 var form = {
                     retirementStartYear: new Date().getFullYear(),
-                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue", floorValue: 40000 }
+                    spending: { initial: 40000, floor: "pensions" }
                 };
                 var sim = [
                     [
                         { portfolio: { start: 1000000 } },
-                        { portfolio: { start: 900000 } },
-                        { portfolio: { start: 1100000 }, cumulativeInflation: 1 },
+                        { portfolio: { start: 1000000 }, socialSecurityAndPensionAdjustments: 50000, cumulativeInflation: 1.5 }
                     ]
                 ];
 
-                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 2);
+                var actualSpending = SpendingModule['notInflationAdjusted'].calcSpending(form, sim, 0, 1);
 
-                expect(actualSpending).toBe(42000);
-            });
-        });
-
-        describe("and it hits the ceiling", function() {
-
-            it("should return the ceiling", function() {
-
-                var form = {
-                    retirementStartYear: new Date().getFullYear(),
-                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue", ceilingValue: 60000 }
-                };
-                var sim = [
-                    [
-                        { portfolio: { start: 1000000 } },
-                        { portfolio: { start: 3000000 }, cumulativeInflation: 1.05 }
-                    ]
-                ];
-
-                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
-
-                expect(actualSpending).toBe(60000 * 1.05);
+                expect(actualSpending).toBe(50000);
             });
         });
     });
@@ -229,6 +109,30 @@ describe("percentOfPortfolio", function() {
                 var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
 
                 expect(actualSpending).toBe(30000 * 1.1);
+            });
+        });
+
+        describe("and a pension floor is hit", function() {
+
+            it("should lower the spending to the floor", function() {
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: {
+                        percentageOfPortfolioPercentage: 4,
+                        percentageOfPortfolioFloorType: "pensions",
+                        percentageOfPortfolioCeilingType: "none"
+                    }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 500000 }, socialSecurityAndPensionAdjustments: 30000, cumulativeInflation: 1.1 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['percentOfPortfolio'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(30000);
             });
         });
 
@@ -471,6 +375,213 @@ describe("percentOfPortfolio", function() {
     });
 });
 
+describe("variableSpending", function() {
+
+    it("should calculate the first years spending in a cycle equal to the initial spending value", function() {
+        var form = {
+            retirementStartYear: new Date().getFullYear(),
+            spending: { initial: 40000 }
+        };
+
+        var actualSpending = SpendingModule['variableSpending'].calcSpending(form, null, 0, 0);
+
+        expect(actualSpending).toBe(form.spending.initial);
+    });
+
+    describe("when the portfolio value decreases from last year", function() {
+
+        it("should adjust the next years spending by the change in portfolio value multiplied by the variable spending ratio", function() {
+            var form = {
+                retirementStartYear: new Date().getFullYear(),
+                spending: { initial: 40000, variableSpendingZValue: 0.5 }
+            };
+            var sim = [
+                [
+                    { portfolio: { start: 1000000 } },
+                    { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
+                ]
+            ];
+
+            var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+            var expectedSpendingAdjustment = (((900000 / (1000000 * 1.05) - 1) * 0.5) + 1)
+            expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
+        });
+
+        describe("and it hits a defined value floor", function() {
+
+            it("should return the floor", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue", floorValue: 40000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(40000 * 1.05);
+            });
+        });
+
+        describe("and it hits a pension floor", function() {
+
+            it("should return the floor", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "pensions" }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 500000 }, socialSecurityAndPensionAdjustments: 35000, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(35000);
+            });
+        });
+
+        describe("and the floor is null", function() {
+
+            it("should not have a floor", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue" }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                var expectedSpendingAdjustment = (((900000 / (1000000 * 1.05) - 1) * 0.5) + 1)
+                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
+            });
+        });
+
+        describe("and it goes back below the ceiling", function() {
+
+            it("should return the adjusted spending", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue", ceilingValue: 60000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 3000000 } },
+                        { portfolio: { start: 1000000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 2);
+
+                var expectedSpendingAdjustment = (((1000000 / (1000000 * 1.05) - 1) * 0.5) + 1);
+                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
+            });
+        });
+
+        describe("and the ceiling is null", function() {
+
+            it("should not have a ceiling", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue" }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 2000000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                var expectedSpendingAdjustment = (((2000000 / (1000000 * 1.05) - 1) * 0.5) + 1);
+                expect(actualSpending).toBe(expectedSpendingAdjustment * 40000 * 1.05);
+            });
+        });
+    });
+
+    describe("when the portfolio value increases from last year", function() {
+
+        it("should adjust the next years spending by the change in portfolio value multiplied by the variable spending ratio", function() {
+            var form = {
+                retirementStartYear: new Date().getFullYear(),
+                spending: { initial: 40000, variableSpendingZValue: 0.5 }
+            };
+            var sim = [
+                [
+                    { portfolio: { start: 1000000 } },
+                    { portfolio: { start: 1100000 }, cumulativeInflation: 1 }
+                ]
+            ];
+
+            var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+            expect(actualSpending).toBe(42000);
+        });
+
+        describe("and it goes above the floor", function() {
+
+            it("should return the adjusted spending", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, floor: "definedValue", floorValue: 40000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 900000 } },
+                        { portfolio: { start: 1100000 }, cumulativeInflation: 1 },
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 2);
+
+                expect(actualSpending).toBe(42000);
+            });
+        });
+
+        describe("and it hits the ceiling", function() {
+
+            it("should return the ceiling", function() {
+
+                var form = {
+                    retirementStartYear: new Date().getFullYear(),
+                    spending: { initial: 40000, variableSpendingZValue: 0.5, ceiling: "definedValue", ceilingValue: 60000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 } },
+                        { portfolio: { start: 3000000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['variableSpending'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(60000 * 1.05);
+            });
+        });
+    });
+});
+
 describe("guytonKlinger", function() {
 
     describe("when the portfolio value stays the same from last year", function() {
@@ -559,28 +670,52 @@ describe("guytonKlinger", function() {
 
     describe("when the portfolio value falls by more than the floor", function() {
 
-        it("should stop the cut at the floor", function() {
-            var form = {
-                retirementStartYear: 2015,
-                retirementEndYear: 2044,
-                spending: { initial: 40000, guytonKlingerExceeds: 20, guytonKlingerCut: 10, guytonKlingerFall: 20, guytonKlingerRaise: 10, floor: "definedValue", floorValue: 38000 }
-            };
-            var sim = [
-                [
-                    { portfolio: { start: 1000000 }, cumulativeInflation: 1, spending: 40000 },
-                    { portfolio: { start: 800000 }, cumulativeInflation: 1.05 }
-                ]
-            ];
+        describe("and there is a defined value floor", function() {
 
-            var actualSpending = SpendingModule['guytonKlinger'].calcSpending(form, sim, 0, 1);
+            it("should stop the cut at the floor", function() {
+                var form = {
+                    retirementStartYear: 2015,
+                    retirementEndYear: 2044,
+                    spending: { initial: 40000, guytonKlingerExceeds: 20, guytonKlingerCut: 10, guytonKlingerFall: 20, guytonKlingerRaise: 10, floor: "definedValue", floorValue: 38000 }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 }, cumulativeInflation: 1, spending: 40000 },
+                        { portfolio: { start: 800000 }, cumulativeInflation: 1.05 }
+                    ]
+                ];
 
-            expect(actualSpending).toBe(Math.round(38000 * 1.05));
+                var actualSpending = SpendingModule['guytonKlinger'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(Math.round(38000 * 1.05));
+            });
+        });
+
+        describe("and there is a pensions floor", function() {
+
+            it("should stop the cut at the floor", function() {
+                var form = {
+                    retirementStartYear: 2015,
+                    retirementEndYear: 2044,
+                    spending: { initial: 40000, guytonKlingerExceeds: 20, guytonKlingerCut: 10, guytonKlingerFall: 20, guytonKlingerRaise: 10, floor: "pensions" }
+                };
+                var sim = [
+                    [
+                        { portfolio: { start: 1000000 }, cumulativeInflation: 1, spending: 40000 },
+                        { portfolio: { start: 800000 }, socialSecurityAndPensionAdjustments: 38000, cumulativeInflation: 1.05 }
+                    ]
+                ];
+
+                var actualSpending = SpendingModule['guytonKlinger'].calcSpending(form, sim, 0, 1);
+
+                expect(actualSpending).toBe(Math.round(38000));
+            });
         });
     });
 
     describe("when the portfolio value falls by more than the fall amount but it within the last 15 years of the simulation", function() {
 
-        it("should stop the cut at the floor", function() {
+        it("should not cut", function() {
             var form = {
                 retirementStartYear: 2015,
                 retirementEndYear: 2044,
@@ -599,7 +734,7 @@ describe("guytonKlinger", function() {
 
     describe("when the portfolio value falls by more than the fall amount but it is just before the last 15 years of the simulation", function() {
 
-        it("should stop the cut at the floor", function() {
+        it("should cut spending by the cut amount", function() {
             var form = {
                 retirementStartYear: 2015,
                 retirementEndYear: 2044,


### PR DESCRIPTION
Added a defined value and pensions/ss floor to the following spending methods:

- Not Inflation Adjusted
- % of Portfolio
- Hebeler Auto Pilot
- Variable Spending
- Guyton-Klinger

Added a defined value ceiling to the following spending methods:

- Not Inflation Adjusted
- Hebeler Auto Pilot

I changed the "calcSumOfAdjustments" to be ran before the "calcSpending" function so the pension floors could be used in the spending calculations.  Also added a field to the simulations array to hold a calculated pensions/ss amount.