### PR TITLE
Fixes a bug causing the portfolio value to go negative when setting a floor with the VPW spending method.

### DIFF
--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -268,7 +268,7 @@ var Simulation = {
 
     },
     roundTwoDecimals: function(num) {
-        return Math.ceil(num * 100) / 100;
+        return Math.ceil(num * 100.0) / 100;
     },
     cumulativeInflation: function(startCPI, endCPI) {
         return 1 + ((endCPI - startCPI) / startCPI);
@@ -285,7 +285,7 @@ var Simulation = {
         var spending;
         var currentYear = new Date().getFullYear();
         if (j >= (form.retirementStartYear - currentYear)) {
-            spending = SpendingModule[form.spending.method].calcSpending(form, this.sim, i, j);
+            spending = this.roundTwoDecimals(SpendingModule[form.spending.method].calcSpending(form, this.sim, i, j));
         } else {
             spending = 0;
         }
@@ -296,7 +296,7 @@ var Simulation = {
     calcMarketGains: function(form, i, j) {
         var portfolio = this.sim[i][j].portfolio.start;
         var sumOfAdjustments = this.sim[i][j].sumOfAdjustments; //Sum of all portfolio adjustments for this given year. SS/Pensions/Extra Income/Extra Spending.
-        portfolio = portfolio - this.sim[i][j].spending + sumOfAdjustments; //Take out spending and portfolio adjustments before calculating asset allocation. This simulates taking your spending out at the beginning of a year.
+        portfolio = this.roundTwoDecimals(portfolio - this.sim[i][j].spending + sumOfAdjustments); //Take out spending and portfolio adjustments before calculating asset allocation. This simulates taking your spending out at the beginning of a year.
 		this.sim[i][j].portfolio.start = portfolio;
         //Calculate value of each asset class based on allocation percentages
         var equities = (form.portfolio.percentEquities / 100 * portfolio);
@@ -341,14 +341,15 @@ var Simulation = {
     },
     calcEndPortfolio: function(form, i, j) {
         if (form.portfolio.rebalanceAnnually == true) {
-            var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start - this.sim[i][j].spending + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
+            var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
             this.sim[i][j].portfolio.fees = feesIncurred;
 
             //Calculate current allocation percentages after all market gains are taken into consideration
-            var curPercEquities = this.sim[i][j].equities.end / (this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
-            var currPercCash = this.sim[i][j].cash.end / (this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
-            var currPercBonds = this.sim[i][j].bonds.end / (this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
-            var currPercGold = this.sim[i][j].gold.end / (this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
+            var totalEnd = this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end;
+            var curPercEquities = this.sim[i][j].equities.end / totalEnd;
+            var currPercCash = this.sim[i][j].cash.end / totalEnd;
+            var currPercBonds = this.sim[i][j].bonds.end / totalEnd;
+            var currPercGold = this.sim[i][j].gold.end / totalEnd;
 
             //Equally distribute fees and portoflio adjustments amongst portfolio based on allocation percentages
             this.sim[i][j].equities.end = this.roundTwoDecimals(this.sim[i][j].equities.end - (curPercEquities * feesIncurred));
@@ -357,7 +358,8 @@ var Simulation = {
             this.sim[i][j].gold.end = this.roundTwoDecimals(this.sim[i][j].gold.end - (currPercGold * feesIncurred));
 
             //Sum all assets to determine portfolio end value.
-            this.sim[i][j].portfolio.end = this.roundTwoDecimals(this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end);
+            totalEnd = this.sim[i][j].equities.end + this.sim[i][j].bonds.end + this.sim[i][j].cash.end + this.sim[i][j].gold.end;
+            this.sim[i][j].portfolio.end = !isNaN(totalEnd) ? this.roundTwoDecimals(totalEnd) : 0;
             this.sim[i][j].portfolio.infAdjEnd = parseInt(this.sim[i][j].portfolio.end / this.sim[i][j].cumulativeInflation);
 
         } else { //Add logic for non-rebalancing portfolios

--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -242,7 +242,7 @@ var Simulation = {
 
     },
     roundTwoDecimals: function(num) {
-        return Math.ceil(num * 100.0) / 100;
+        return +parseFloat(num).toFixed(2);
     },
     cumulativeInflation: function(startCPI, endCPI) {
         return 1 + ((endCPI - startCPI) / startCPI);

--- a/js/spendingModule.js
+++ b/js/spendingModule.js
@@ -132,7 +132,7 @@ var SpendingModule = {
             var floor = SpendingModule.calcBasicSpendingFloor(form, sim, i, j);
             var ceiling = SpendingModule.calcBasicSpendingCeiling(form, sim, i, j);
 
-            var uncappedSpending = -SpendingModule.calcPayment(form.spending.vpwRateOfReturn / 100, yearsLeftInSimulation, sim[i][j].portfolio.start, Number(form.spending.vpwFutureValue));
+            var uncappedSpending = -SpendingModule.calcPayment(form.spending.vpwRateOfReturn / 100, yearsLeftInSimulation, sim[i][j].portfolio.start, Number(form.spending.vpwFutureValue * sim[i][j].cumulativeInflation));
             var cappedSpending = Math.min(Math.max(uncappedSpending, floor), ceiling);
 
             return Math.min(Math.max(uncappedSpending, floor), ceiling);

--- a/js/spendingModule.js
+++ b/js/spendingModule.js
@@ -133,14 +133,16 @@ var SpendingModule = {
             var ceiling = SpendingModule.calcBasicSpendingCeiling(form, sim, i, j);
 
             var uncappedSpending = -SpendingModule.calcPayment(form.spending.vpwRateOfReturn / 100, yearsLeftInSimulation, sim[i][j].portfolio.start, Number(form.spending.vpwFutureValue));
-            return Math.round(Math.min(Math.max(uncappedSpending, floor), ceiling));
+            var cappedSpending = Math.min(Math.max(uncappedSpending, floor), ceiling);
+
+            return Math.min(Math.max(uncappedSpending, floor), ceiling);
         }
     },
     calcBasicSpendingFloor: function(form, sim, i, j) {
         if(form.spending.floor == 'definedValue' && "floorValue" in form.spending) {
-            return form.spending.floorValue * sim[i][j].cumulativeInflation;
+            return Math.min(form.spending.floorValue * sim[i][j].cumulativeInflation, sim[i][j].portfolio.start);
         } else if (form.spending.floor == "pensions" && sim[i][j].socialSecurityAndPensionAdjustments != null){
-            return sim[i][j].socialSecurityAndPensionAdjustments;
+            return Math.min(sim[i][j].socialSecurityAndPensionAdjustments, sim[i][j].portfolio.start);
         }
         return 0;
     },


### PR DESCRIPTION
Addresses #52.

Probably should have broken this out into multiple commits, but this also fixes a couple other issues.

First, is that the calculating the portfolio fees was slightly off.  The "calcMarketGains" function calculates the current sim.portfolio.start value by subtracting spending and adding adjustments.  Afterwards "calcEndPortfolio" gets called and was calculating the portfolio fees by subtracting out the spending again.  Just removed the extra subtraction when calculating fees.  I found this because the VPW spending method was drawing down to a number slightly higher than $0 at the end.

Second, the "roundTwoDecimals" function wasn't actually rounding to two decimals.  This was causing some of the VPW scenarios to finish with $0.01 left, rather than $0.  Used the rounding method found [here](http://stackoverflow.com/questions/15762768/javascript-math-round-to-two-decimal-places).

Third, when the portfolio ended at exactly $0, it was causing the ending portfolio value to be NaN because of divide by zero issues.