### PR TITLE
Fix issue with fee computation

### DIFF
--- a/js/cFIREsimOpen.js
+++ b/js/cFIREsimOpen.js
@@ -422,7 +422,7 @@ var Simulation = {
             this.sim[i][j].portfolio.infAdjEnd = parseInt(this.sim[i][j].portfolio.end / this.sim[i][j].cumulativeInflation);
 
         } else { //Add logic for non-rebalancing portfolios
-			var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start - this.sim[i][j].spending + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
+			var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
             this.sim[i][j].portfolio.fees = feesIncurred;
 
             //Calculate current allocation percentages after all market gains are taken into consideration


### PR DESCRIPTION
I believe that the fees calculation for non-balanced portfolios is incorrect. This PR corrects the problem I've identified.

tl;dr, the fee is too low because the spending is deducted **twice** from the initial value before the fee is calculated.

This is the code fees calculation for non-rebalanced portfolios ([link](https://github.com/boknows/cFIREsim-open/blob/a85287a40741448f817d073ab17ccb4504731ae4/js/cFIREsimOpen.js#L425)):

```js
var feesIncurred = this.roundTwoDecimals((this.sim[i][j].portfolio.start - this.sim[i][j].spending + this.sim[i][j].equities.growth + this.sim[i][j].bonds.growth + this.sim[i][j].cash.growth + this.sim[i][j].gold.growth) * (form.portfolio.percentFees / 100));
```

The important part here is this part: `this.sim[i][j].portfolio.start - this.sim[i][j].spending`.

We can see that the spending is deducted from the portfolio start. This happens in the method `calcEndPortfolio`. If we look [at the loop that computes the "cycle,"](https://github.com/boknows/cFIREsim-open/blob/a85287a40741448f817d073ab17ccb4504731ae4/js/cFIREsimOpen.js#L205-L206) we see that `calcEndPortfolio` is called _after_ `calcMarketGains`. This is important because `calcMarketGains` [has already subtracted the spending](https://github.com/boknows/cFIREsim-open/blob/a85287a40741448f817d073ab17ccb4504731ae4/js/cFIREsimOpen.js#L359-L362)!

An easy way to verify this is the following:

1. Set constant growth of the portfolio - `0%`
2. Set fees/drag to 0
3. Set your portfolio to some amount (I used 625k)
4. Set withdrawal to some amount (I used 25k)
5. Put a breakpoint on the line that computes the fee, or console.log the value of `this.sim[i][j].portfolio.start`

In this situation, I would expect the first cycle to compute fees off of 600k, but it computes it off of 575k.

Because this is computing fees that are too low, non-rebalancing portfolios are producing results that are _too optimistic_.

Thanks for reading!